### PR TITLE
Fixed the CSS on Venues and Venues Show

### DIFF
--- a/app/views/venues/index.html.erb
+++ b/app/views/venues/index.html.erb
@@ -43,24 +43,20 @@
         <th>Name</th>
         <th>Address</th>
         <th>Neighborhood</th>
-        <th>Actions</th>
       </tr>
       
       <% @venues.each do |bookmark_venue| %>
         <tr>
-          <td><%= bookmark_venue.name %></td>
+          <td>
+            <a href="/venues/<%= bookmark_venue.id %>"><%= bookmark_venue.name %></a>
+          </td>
           <td><%= bookmark_venue.address %></td>
           <td>
             <% if bookmark_venue.neighborhood.present? %>
-              <a href="/neighborhoods/<%= bookmark_venue.neighborhood.id %>">
-                <%= bookmark_venue.neighborhood.name %>
-              </a>
+              <small>
+                <%= bookmark_venue.neighborhood.name %>, Chicago
+              </small>
             <% end %>
-          </td>
-          <td>
-            <a href="/venues/<%= bookmark_venue.id %>" class="btn btn-primary">Show</a>
-            <a href="/venues/<%= bookmark_venue.id %>/edit" class="btn btn-warning">Edit</a>
-            <a href="/delete_venue/<%= bookmark_venue.id %>" class="btn btn-danger" rel="nofollow">Delete</a>
           </td>
         </tr>
       <% end %>

--- a/app/views/venues/show.html.erb
+++ b/app/views/venues/show.html.erb
@@ -1,172 +1,65 @@
-<div class="page-header">
-  <h3>Venue #<%= @venue.id %></h3>
-</div>
 
-<div class="row">
-  <div class="col-md-12 mb-2">
-    <dl class="dl-horizontal">
-      <dt>Name</dt>
-      <dd><%= @venue.name %></dd>
-
-      <dt>Address</dt>
-      <dd>
+<div class="container mt-4">
+  <div class="row mt-4 justify-content-md-center">
+    <div class="col-md-6">
+      <div class="card">
+        <div class="card-header">
+          <div class="card-title">
+            <h4>
+              <%= @venue.name %> 
+              <small>
+                <%= @venue.address %>
+              </small>
+            </h4>
+          </div>
+        </div>
         <div>
           <div id="location_map" style="height: 480px;"></div>
         </div>
-      </dd>
-
-      <dt>Neighborhood</dt>
-      <dd>
-        <% if @venue.neighborhood.present? %>
-          <a href="/neighborhoods/<%= @venue.neighborhood_id %>">
-            <%= @venue.neighborhood.name %>
+        <ul class="list-group">
+          <li class="list-group-item list-group-item-success">
+            Dishes you loved here
+          </li>
+          <% @venue.bookmarks.where("user_id=?",current_user.id).each do |bookmark| %>
+          <li class="list-group-item">
+            <p><a href="/dishes/<%= bookmark.dish.id %>"> 
+              <%= bookmark.dish.name %>
+            </a></p>
+          </li>
+          <% end %>
+          <li class="list-group-item">
+            <form action="/create_bookmark" class="form-inline" method="post">
+              <%= select_tag("dish_id", options_from_collection_for_select(Dish.all, :id, :name), :class => "form-control form-control-sm mr-sm-1",:prompt => 'Choose a venue...') %>
+              <input name="authenticity_token" type="hidden" value="<%= form_authenticity_token %>">
+              <input type="hidden" name="venue_id" value="<%= @venue.id %>">
+              <input type="hidden" name="user_id" value="<%= current_user.id %>">
+              <button class="btn btn-primary btn-sm">
+                <i class="fa fa-heart"></i>
+              </button>
+            </form>
+          </li>
+          <li class="list-group-item list-group-item-success">
+            Popular dishes here
+          </li>
+          <% @venue.specialties.select('DISTINCT name').each do |specialty| %>
+          <li class="list-group-item">
+            <a href="/dishes/<%= specialty.id %>">
+            <%= specialty.name %>
+            </a>
+          </li>
+          <% end %>
+        </ul>
+        <div class="card-footer text-center">
+          <a href="/dishes" class="btn btn-block btn-secondary">
+            Back
           </a>
-        <% end %>
-      </dd>
-
-    </dl>
-
-    <div class="btn-group btn-group-justified">
-      <a href="/venues" class="btn btn-primary">
-        Back
-      </a>
-      <a href="/venues/<%= @venue.id %>/edit" class="btn btn-warning">
-        Edit
-      </a>
-      <a href="/delete_venue/<%= @venue.id %>" class="btn btn-danger" rel="nofollow">
-        Delete
-      </a>
+        </div>
+      </div>
     </div>
   </div>
 </div>
 
-<!-- A Venue has many bookmarks -->
 
-<div class="row">
-  <div class="col-md-12">
-    <ul class="list-group">
-      <li class="list-group-item list-group-item-info">
-        Bookmarks
-      </li>
-
-      <% @venue.bookmarks.each do |bookmark| %>
-        <li class="list-group-item">
-          <a href="/bookmarks/<%= bookmark.id %>">
-            <%= bookmark.notes %>
-          </a>
-          <div class="btn-group btn-group-xs float-right">
-            <a href="/bookmarks/<%= bookmark.id %>" class="btn btn-primary">
-              <i class="fa fa-search-plus"></i>
-            </a>
-            <a href="/bookmarks/<%= bookmark.id %>/edit" class="btn btn-warning">
-              <i class="fa fa-edit"></i>
-            </a>
-            <a href="/delete_bookmark/<%= bookmark.id %>" class="btn btn-danger" rel="nofollow">
-              <i class="fa fa-trash-o"></i>
-            </a>
-          </div>
-        </li>
-      <% end %>
-
-      <li class="list-group-item">
-        <form action="/create_bookmark" method="post">
-      <!-- Hidden input for authenticity token to protect from forgery -->
-      <input name="authenticity_token" type="hidden" value="<%= form_authenticity_token %>">
-
-      <!-- Label and input for dish_id -->
-      <div class="form-group">
-        <label for="dish_id" class="control-label">
-          Dish
-        </label>
-
-        <%= select_tag(:dish_id, options_from_collection_for_select(Dish.all, :id, :name), :class => "form-control") %>
-      </div>
-
-      <!-- Label and input for venue_id -->
-      <input type="hidden" name="venue_id" value="<%= @venue.id %>">
-
-      <!-- Label and input for user_id -->
-      <input type="hidden" name="user_id" value="<%= current_user.id %>">
-
-      <!-- Label and input for notes -->
-      <div class="form-group">
-        <label for="notes" class="control-label">
-          Notes
-        </label>
-
-        <textarea id="notes" name="notes" placeholder="Notes" class="form-control" rows="3"></textarea>
-      </div>
-
-      <button class="btn btn-block btn-success">
-        Create Bookmark
-      </button>
-    </form>
-      </li>
-    </ul>
-  </div>
-</div>
-
-<!-- A Venue has many fans -->
-
-<div class="row">
-  <div class="col-md-12">
-    <ul class="list-group">
-      <li class="list-group-item list-group-item-info">
-        Fans
-      </li>
-
-      <% @venue.fans.each do |user| %>
-        <li class="list-group-item">
-          <a href="/users/<%= user.id %>">
-            <%= user.username %>
-          </a>
-          <div class="btn-group btn-group-xs float-right">
-            <a href="/users/<%= user.id %>" class="btn btn-primary">
-              <i class="fa fa-search-plus"></i>
-            </a>
-            <a href="/users/<%= user.id %>/edit" class="btn btn-warning">
-              <i class="fa fa-edit"></i>
-            </a>
-            <a href="/delete_user/<%= user.id %>" class="btn btn-danger" rel="nofollow">
-              <i class="fa fa-trash-o"></i>
-            </a>
-          </div>
-        </li>
-      <% end %>
-    </ul>
-  </div>
-</div>
-
-<!-- A Venue has many specialties -->
-
-<div class="row">
-  <div class="col-md-12">
-    <ul class="list-group">
-      <li class="list-group-item list-group-item-info">
-        Specialties
-      </li>
-
-      <% @venue.specialties.each do |dish| %>
-        <li class="list-group-item">
-          <a href="/dishes/<%= dish.id %>">
-            <%= dish.name %>
-          </a>
-          <div class="btn-group btn-group-xs float-right">
-            <a href="/dishes/<%= dish.id %>" class="btn btn-primary">
-              <i class="fa fa-search-plus"></i>
-            </a>
-            <a href="/dishes/<%= dish.id %>/edit" class="btn btn-warning">
-              <i class="fa fa-edit"></i>
-            </a>
-            <a href="/delete_dish/<%= dish.id %>" class="btn btn-danger" rel="nofollow">
-              <i class="fa fa-trash-o"></i>
-            </a>
-          </div>
-        </li>
-      <% end %>
-    </ul>
-  </div>
-</div>
 
 
 <script src="//maps.google.com/maps/api/js?v=3.24&key=AIzaSyCOTPWiuvyyo6sKoIBzKA4-1ol-vTOIOlM"></script>


### PR DESCRIPTION
Fixed the layout of the Venues page to better reflect that on the target (which is prettier). I didn't go for all the same styling because I personally think our is better with the address shown for quick reference, etc. 

I also modified the page for each venue's show page. It's more compact and still conveys all the necessary info (without the ability to remove other people's bookmarks). You can also add new bookmarks from there on the fly.

Note the query style for the listing of "specialties".